### PR TITLE
Requeue functionality

### DIFF
--- a/consumer.go
+++ b/consumer.go
@@ -126,6 +126,10 @@ func (c Consumer) createQueues(channel *amqp.Channel) error {
 		amqpTable["x-queue-type"] = "quorum"
 	}
 
+	if c.options.quorumQueue && c.options.retries != 0 {
+		amqpTable["x-delivery-count"] = c.options.retries
+	}
+
 	if c.options.deadLetterQueue != "" {
 		amqpTable = amqp.Table{
 			"x-dead-letter-exchange":    fmt.Sprintf("%s-exchange", c.options.deadLetterQueue),

--- a/consumer.go
+++ b/consumer.go
@@ -126,15 +126,15 @@ func (c Consumer) createQueues(channel *amqp.Channel) error {
 		amqpTable["x-queue-type"] = "quorum"
 	}
 
-	if c.options.quorumQueue && c.options.retries != 0 {
-		amqpTable["x-delivery-count"] = c.options.retries
+	if c.options.retries != 0 {
+		if !c.options.quorumQueue {
+			return fmt.Errorf("to enable retries, you need to use quorum queues.")
+		}
 	}
 
 	if c.options.deadLetterQueue != "" {
-		amqpTable = amqp.Table{
-			"x-dead-letter-exchange":    fmt.Sprintf("%s-exchange", c.options.deadLetterQueue),
-			"x-dead-letter-routing-key": "",
-		}
+		amqpTable["x-dead-letter-exchange"] = fmt.Sprintf("%s-exchange", c.options.deadLetterQueue)
+		amqpTable["x-dead-letter-routing-key"] = ""
 
 		_, err := channel.QueueDeclare(
 			c.options.deadLetterQueue,

--- a/consumer.go
+++ b/consumer.go
@@ -126,7 +126,7 @@ func (c Consumer) createQueues(channel *amqp.Channel) error {
 		amqpTable["x-queue-type"] = "quorum"
 	}
 
-	if c.options.retries != 0 {
+	if c.options.retries > 0 {
 		if !c.options.quorumQueue {
 			return fmt.Errorf("to enable retries, you need to use quorum queues.")
 		}

--- a/consumerLoop.go
+++ b/consumerLoop.go
@@ -72,10 +72,6 @@ func (c Consumer) shouldRetry(headers amqp.Table) bool {
 		return true
 	}
 
-	r, ok := retries.(int64)
-	if !ok {
-		return false
-	}
-
+	r, _ := retries.(int64)
 	return c.options.retries > int(r)
 }

--- a/consumerLoop.go
+++ b/consumerLoop.go
@@ -37,7 +37,8 @@ func (c Consumer) loop(channel *amqp.Channel, deliveries <-chan amqp.Delivery) {
 		if err := handler(tracingCtx, uevt); err != nil {
 			elapsed := time.Since(startTime).Milliseconds()
 			notifyEventHandlerFailed(c.options.notificationCh, deliveryInfo.RoutingKey, elapsed, err)
-			_ = delivery.Nack(false, false)
+			requeue := c.options.quorumQueue && c.options.retries != 0
+			_ = delivery.Nack(false, requeue)
 			EventNack(c.queueName, deliveryInfo.RoutingKey, elapsed)
 			continue
 		}

--- a/consumerLoop.go
+++ b/consumerLoop.go
@@ -62,7 +62,7 @@ func (c Consumer) loop(channel *amqp.Channel, deliveries <-chan amqp.Delivery) {
 }
 
 func (c Consumer) shouldRetry(headers amqp.Table) bool {
-	if !(c.options.retries > 0) {
+	if c.options.retries <= 0 {
 		return false
 	}
 

--- a/consumerOption.go
+++ b/consumerOption.go
@@ -40,7 +40,10 @@ func WithQuorumQueue() func(*consumerOption) {
 	}
 }
 
-// WithRetries specifies the retries count
+// WithRetries specifies the retries count before the event is discarded or sent to dead letter.
+// Quorum queues are required to use this feature.
+// The event will be processed at max as retries + 1.
+// If specified amount is 3, the event can be processed up to 4 times.
 func WithRetries(retries int) func(*consumerOption) {
 	return func(opt *consumerOption) {
 		opt.retries = retries

--- a/consumerOption.go
+++ b/consumerOption.go
@@ -13,6 +13,7 @@ type consumerOption struct {
 	prefetchSize    int
 	quorumQueue     bool
 	notificationCh  chan<- Notification
+	retries         int
 }
 
 // WithBindingToExchange specifies the exchange on which the queue
@@ -36,6 +37,13 @@ func WithQoS(prefetchCount, prefetchSize int) func(*consumerOption) {
 func WithQuorumQueue() func(*consumerOption) {
 	return func(opt *consumerOption) {
 		opt.quorumQueue = true
+	}
+}
+
+// WithRetries specifies the retries count
+func WithRetries(retries int) func(*consumerOption) {
+	return func(opt *consumerOption) {
+		opt.retries = retries
 	}
 }
 

--- a/tests/consumer_retries_test.go
+++ b/tests/consumer_retries_test.go
@@ -1,0 +1,194 @@
+package tests
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/pmorelli92/bunnify"
+	"go.uber.org/goleak"
+)
+
+func TestConsumerRetriesShouldFailWhenNoQuorumQueues(t *testing.T) {
+	// Setup
+	queueName := uuid.NewString()
+	exchangeName := uuid.NewString()
+
+	// Exercise
+	connection := bunnify.NewConnection()
+	if err := connection.Start(); err != nil {
+		t.Fatal(err)
+	}
+
+	consumer := connection.NewConsumer(
+		queueName,
+		bunnify.WithRetries(1),
+		bunnify.WithBindingToExchange(exchangeName),
+		bunnify.WithDefaultHandler(func(ctx context.Context, event bunnify.ConsumableEvent[json.RawMessage]) error {
+			return nil
+		}))
+
+	err := consumer.Consume()
+	if err == nil {
+		t.Fatal("expected error as retry cannot be used without quorum queues")
+	}
+
+	if err := connection.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	goleak.VerifyNone(t)
+}
+
+func TestConsumerRetries(t *testing.T) {
+	// Setup
+	queueName := uuid.NewString()
+	exchangeName := uuid.NewString()
+	routingKey := "order.orderCreated"
+	expectedRetries := 2
+
+	type orderCreated struct {
+		ID string `json:"id"`
+	}
+
+	publishedOrderCreated := orderCreated{
+		ID: uuid.NewString(),
+	}
+	publishedEvent := bunnify.NewPublishableEvent(
+		publishedOrderCreated,
+		bunnify.WithEventID("custom-event-id"),
+		bunnify.WithCorrelationID("custom-correlation-id"),
+	)
+
+	actualProcessing := 0
+	eventHandler := func(ctx context.Context, event bunnify.ConsumableEvent[orderCreated]) error {
+		actualProcessing++
+		return fmt.Errorf("error, this event should be retried")
+	}
+
+	// Exercise
+	connection := bunnify.NewConnection()
+	if err := connection.Start(); err != nil {
+		t.Fatal(err)
+	}
+
+	consumer := connection.NewConsumer(
+		queueName,
+		bunnify.WithQuorumQueue(),
+		bunnify.WithRetries(expectedRetries),
+		bunnify.WithBindingToExchange(exchangeName),
+		bunnify.WithHandler(routingKey, eventHandler))
+
+	if err := consumer.Consume(); err != nil {
+		t.Fatal(err)
+	}
+
+	publisher := connection.NewPublisher()
+
+	err := publisher.Publish(context.TODO(), exchangeName, routingKey, publishedEvent)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	time.Sleep(50 * time.Millisecond)
+
+	if err := connection.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Assert
+	expectedProcessing := expectedRetries + 1
+	if expectedProcessing != actualProcessing {
+		t.Fatalf("expected processing %d, got %d", expectedProcessing, actualProcessing)
+	}
+
+	goleak.VerifyNone(t)
+}
+
+func TestConsumerRetriesWithDeadLetterQueue(t *testing.T) {
+	// Setup
+	queueName := uuid.NewString()
+	deadLetterQueueName := uuid.NewString()
+	exchangeName := uuid.NewString()
+	routingKey := "order.orderCreated"
+	expectedRetries := 2
+
+	type orderCreated struct {
+		ID string `json:"id"`
+	}
+
+	publishedOrderCreated := orderCreated{
+		ID: uuid.NewString(),
+	}
+	publishedEvent := bunnify.NewPublishableEvent(
+		publishedOrderCreated,
+		bunnify.WithEventID("custom-event-id"),
+		bunnify.WithCorrelationID("custom-correlation-id"),
+	)
+
+	actualProcessing := 0
+	eventHandler := func(ctx context.Context, event bunnify.ConsumableEvent[orderCreated]) error {
+		actualProcessing++
+		return fmt.Errorf("error, this event will go to dead-letter")
+	}
+
+	var deadEvent bunnify.ConsumableEvent[orderCreated]
+	deadEventHandler := func(ctx context.Context, event bunnify.ConsumableEvent[orderCreated]) error {
+		deadEvent = event
+		return nil
+	}
+
+	// Exercise
+	connection := bunnify.NewConnection()
+	if err := connection.Start(); err != nil {
+		t.Fatal(err)
+	}
+
+	consumer := connection.NewConsumer(
+		queueName,
+		bunnify.WithQuorumQueue(),
+		bunnify.WithRetries(expectedRetries),
+		bunnify.WithBindingToExchange(exchangeName),
+		bunnify.WithHandler(routingKey, eventHandler),
+		bunnify.WithDeadLetterQueue(deadLetterQueueName))
+
+	if err := consumer.Consume(); err != nil {
+		t.Fatal(err)
+	}
+
+	deadLetterConsumer := connection.NewConsumer(
+		deadLetterQueueName,
+		bunnify.WithHandler(routingKey, deadEventHandler))
+
+	if err := deadLetterConsumer.Consume(); err != nil {
+		t.Fatal(err)
+	}
+
+	publisher := connection.NewPublisher()
+
+	err := publisher.Publish(context.TODO(), exchangeName, routingKey, publishedEvent)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	time.Sleep(50 * time.Millisecond)
+
+	if err := connection.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Assert
+	expectedProcessing := expectedRetries + 1
+	if expectedProcessing != actualProcessing {
+		t.Fatalf("expected processing %d, got %d", expectedProcessing, actualProcessing)
+	}
+
+	if publishedEvent.ID != deadEvent.ID {
+		t.Fatalf("expected event ID %s, got %s", publishedEvent.ID, deadEvent.ID)
+	}
+
+	goleak.VerifyNone(t)
+}


### PR DESCRIPTION
- Fixed a bug where quorum queues will not work with dead lettering.
- Added re-queue functionality using the `x-delivery-count` header.

This could be implemented with the `delivery-limit` policy, however the current `go-amqp` version does not support policies. In order not to couple myself with that, or doing manual HTTP calls, I decided to go with a more flexible approach where the retry amount can also be dynamically modified even after queue creation.